### PR TITLE
changes to memory and mutex extraction

### DIFF
--- a/migoinfer/inferer.go
+++ b/migoinfer/inferer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"strings"
 
 	"github.com/nickng/gospal/callctx"
 	"github.com/nickng/gospal/funcs"
@@ -108,7 +109,10 @@ func (i *Inferer) Analyse() {
 			}
 		}
 		for _, f := range i.Env.Prog.Funcs {
-			if f.SimpleName() != "main.main" {
+			if f.SimpleName() != "main.main" && !strings.HasPrefix(f.SimpleName(), "os") &&
+				!strings.HasPrefix(f.SimpleName(), "syscall") &&
+				!strings.HasPrefix(f.SimpleName(), "internal_poll") &&
+				!strings.HasPrefix(f.SimpleName(), "sync.o") {
 				fmt.Fprintf(i.outWriter, f.String())
 			}
 		}

--- a/migoinfer/internal/migoinfer/func.go
+++ b/migoinfer/internal/migoinfer/func.go
@@ -102,6 +102,9 @@ func (f *Function) exportParams() {
 					}
 				}
 			}
+			if typeIsRWMutex(param.Type()) || typeIsMutex(param.Type()) {
+				f.Export(param)
+			}
 		} else if isPtrBasic(param) {
 			f.Export(param)
 		}

--- a/migoinfer/internal/migoinfer/migo.go
+++ b/migoinfer/internal/migoinfer/migo.go
@@ -341,6 +341,9 @@ func paramsToMigoParam(v *Instruction, fn *Function, call *funcs.Call) []*migo.P
 		if isPtrBasic(arg) {
 			migoParams = append(migoParams, convertToMigoParam(arg, call.Definition().Param(i)))
 		}
+		if typeIsMutex(arg.Type()) || typeIsRWMutex(arg.Type()) {
+			migoParams = append(migoParams, convertToMigoParam(arg, call.Definition().Param(i)))
+		}
 	}
 	// Convert return value.
 	for i, param := range call.Parameters[call.NParam()+call.NBind():] {

--- a/migoinfer/internal/migoinfer/migo_mem.go
+++ b/migoinfer/internal/migoinfer/migo_mem.go
@@ -3,40 +3,47 @@ package migoinfer
 import (
 	"github.com/nickng/gospal/store"
 	"github.com/nickng/migo/v3"
+	"strings"
 )
 
-func migoNewMem(mem store.Value) migo.Statement {
-	return &migo.NewMem{Name: mem.UniqName()}
+func migoNewMem(mem migo.NamedVar) migo.Statement {
+	return &migo.NewMem{Name: mem}
 }
 
-func migoRead(mem store.Value) migo.Statement {
-	return &migo.MemRead{Name: mem.UniqName()}
+func migoRead(v *Instruction, local store.Key) migo.Statement {
+	if !strings.Contains(v.Get(local).UniqName(), "mem") { // If not a local memory field.
+		return &migo.TauStatement{} //&migo.MemWrite{Name: v.Get(local).UniqName()}
+	}
+	return &migo.MemRead{Name: local.Name()}
 }
 
-func migoWrite(mem store.Value) migo.Statement {
-	return &migo.MemWrite{Name: mem.UniqName()}
+func migoWrite(v *Instruction, local store.Key) migo.Statement {
+	if !strings.Contains(v.Get(local).UniqName(), "mem") { // If not a local memory field.
+		return &migo.TauStatement{} //&migo.MemWrite{Name: v.Get(local).UniqName()}
+	}
+	return &migo.MemWrite{Name: local.Name()}
 }
 
-func migoNewMutex(mu store.Value) migo.Statement {
-	return &migo.NewSyncMutex{Name: mu.UniqName()}
+func migoNewMutex(mu migo.NamedVar) migo.Statement {
+	return &migo.NewSyncMutex{Name: mu}
 }
 
-func migoLock(mu store.Value) migo.Statement {
-	return &migo.SyncMutexLock{Name: mu.UniqName()}
+func migoLock(mu store.Key) migo.Statement {
+	return &migo.SyncMutexLock{Name: mu.Name()}
 }
 
-func migoUnlock(mu store.Value) migo.Statement {
-	return &migo.SyncMutexUnlock{Name: mu.UniqName()}
+func migoUnlock(mu store.Key) migo.Statement {
+	return &migo.SyncMutexUnlock{Name: mu.Name()}
 }
 
-func migoNewRWMutex(mu store.Value) migo.Statement {
-	return &migo.NewSyncRWMutex{Name: mu.UniqName()}
+func migoNewRWMutex(mu migo.NamedVar) migo.Statement {
+	return &migo.NewSyncRWMutex{Name: mu}
 }
 
-func migoRLock(mu store.Value) migo.Statement {
-	return &migo.SyncRWMutexRLock{Name: mu.UniqName()}
+func migoRLock(mu store.Key) migo.Statement {
+	return &migo.SyncRWMutexRLock{Name: mu.Name()}
 }
 
-func migoRUnlock(mu store.Value) migo.Statement {
-	return &migo.SyncRWMutexRUnlock{Name: mu.UniqName()}
+func migoRUnlock(mu store.Key) migo.Statement {
+	return &migo.SyncRWMutexRUnlock{Name: mu.Name()}
 }

--- a/store/mems/mems.go
+++ b/store/mems/mems.go
@@ -27,3 +27,7 @@ func New(callsite store.Value, val ssa.Value) *Mem {
 func (m *Mem) UniqName() string {
 	return fmt.Sprintf("%s.%s_mem.%v", m.namespace.UniqName(), m.Value.Name(), m.Pos())
 }
+
+func (m *Mem) Name() string {
+	return fmt.Sprintf(m.Value.Name())
+}

--- a/store/muts/muts.go
+++ b/store/muts/muts.go
@@ -1,0 +1,28 @@
+// Package muts implements store.Value for (rw)mutex locks.
+package muts
+
+import (
+	"fmt"
+
+	"github.com/nickng/gospal/store"
+	"golang.org/x/tools/go/ssa"
+)
+
+// Mut is a wrapper for a Mutex lock SSA-value.
+type Mut struct {
+	ssa.Value
+
+	namespace store.Value
+}
+
+// New returns a new mut.
+func New(callsite store.Value, val ssa.Value) *Mut {
+	return &Mut{
+		Value:     val,
+		namespace: callsite,
+	}
+}
+
+func (m *Mut) UniqName() string {
+	return fmt.Sprintf("%s.%s_mut.%v", m.namespace.UniqName(), m.Value.Name(), m.Pos())
+}


### PR DESCRIPTION
There's quite a few things in there, including:
- a (somewhat hacky) way of not printing functions that are part of the go runtime and not the inferred program (in `migoinfer/inferer.go` and `migoinfer/internal/migoinfer/migo.go`, mainly)
-- this is based on filtering out some keywords and probably doesn't contain some other packages, including the `net` package that I don't use in my examples
- adding export for (rw)mutex parameters, as well as slight changes to the way their names (and the shared memory ones) are extracted to unify with channel extracted names
- a (somewhat hacky) way to filter memory accesses that are not done to shared variables of the program (those are extracted by us with the `mem` keyword in their `uniqName`, so I seach for that to filter out anything not having it)
- slight change to the way mutex and shared variables are handled by migo (needs the update to migo that I will PR as well in a minute)

Obviously, anything in there is up for discussion, especially if we want to keep the output as "pure" as possible, the first hack that filters out non-program functions can be easily reverted, and if you find some of the additions are misplaced I'm happy to know where they would have their better place